### PR TITLE
Implement reporting

### DIFF
--- a/pywikitools/resourcesbot/bot.py
+++ b/pywikitools/resourcesbot/bot.py
@@ -236,6 +236,7 @@ class ResourcesBot:
             )
 
         reporting.print_summaries(module_reports)
+        reporting.save_report(self.site, module_reports)
 
     def get_english_version(self, page_source: str) -> Tuple[str, int]:
         """

--- a/pywikitools/resourcesbot/modules/consistency_checks.py
+++ b/pywikitools/resourcesbot/modules/consistency_checks.py
@@ -322,6 +322,6 @@ class ConsistencyLanguageReport(LanguageReport):
         total_checks_passed = sum(report.checks_passed for report in lang_reports)
         consistent_reports = [report for report in lang_reports if report.consistent()]
 
-        return (f"Ran Consistency checks for {len(lang_reports)} languages.\n"
+        return (f"Ran Consistency checks for {len(lang_reports)} languages. "
                 f"Consistent languages: {len(consistent_reports)}/{len(lang_reports)}, "
                 f"Overall: {total_checks_passed}/{len(lang_reports) * 5} checks passed.")

--- a/pywikitools/resourcesbot/modules/export_pdf.py
+++ b/pywikitools/resourcesbot/modules/export_pdf.py
@@ -11,6 +11,7 @@ from pywikitools.fortraininglib import ForTrainingLib
 from pywikitools.resourcesbot.changes import ChangeLog
 from pywikitools.resourcesbot.data_structures import FileInfo, LanguageInfo
 from pywikitools.resourcesbot.modules.post_processing import LanguagePostProcessor
+from pywikitools.resourcesbot.reporting import LanguageReport
 
 
 class ExportPDF(LanguagePostProcessor):
@@ -117,3 +118,33 @@ class ExportPDF(LanguagePostProcessor):
                 self.logger.info(f"Successfully downloaded and saved {file_path}")
 
         self.logger.info(f"ExportPDF {lang_code}: Downloaded {file_counter} PDF files")
+        lang_report = PdfLanguageReport(lang_info.language_code, file_counter)
+        return lang_report
+
+
+class PdfLanguageReport(LanguageReport):
+    """
+    A specialized report for export_pdf,
+    containing information about saved pdfs
+    """
+
+    def __init__(self, language_code: str, pdf_counter: int):
+        super().__init__(language_code)
+
+        self.pdf_counter = pdf_counter
+
+    @classmethod
+    def get_module_name(cls) -> str:
+        return "export_pdf"
+
+    def get_summary(self) -> str:
+        return (f"Ran ExportHTML for {self.language}: Downloaded {self.pdf_counter} pdfs.")
+
+    @classmethod
+    def get_module_summary(cls, lang_reports: list) -> str:
+        if len(lang_reports) == 0:
+            return ""
+
+        total_pdfs = sum(report.pdf_counter for report in lang_reports)
+
+        return (f"Ran export_pdf for {len(lang_reports)} languages: Downloaded {total_pdfs} pdfs.")

--- a/pywikitools/resourcesbot/modules/write_report.py
+++ b/pywikitools/resourcesbot/modules/write_report.py
@@ -178,6 +178,7 @@ class WriteReport(LanguagePostProcessor):
             )
             page.text = report
             page.save("Created language report")
+            self.lang_report.updated_language_report = True
         else:
             if page.text.strip() != report.strip():
                 page.text = report

--- a/pywikitools/resourcesbot/modules/write_report.py
+++ b/pywikitools/resourcesbot/modules/write_report.py
@@ -10,6 +10,7 @@ from pywikitools.fortraininglib import ForTrainingLib
 from pywikitools.resourcesbot.changes import ChangeLog
 from pywikitools.resourcesbot.data_structures import LanguageInfo, WorksheetInfo
 from pywikitools.resourcesbot.modules.post_processing import LanguagePostProcessor
+from pywikitools.resourcesbot.reporting import LanguageReport
 
 
 class Color(Enum):
@@ -57,6 +58,7 @@ class WriteReport(LanguagePostProcessor):
             site: our pywikibot object to be able to write to the mediawiki system
         """
         super().__init__(fortraininglib, config, site)
+        self.lang_report = WriteReportLanguageReport("")
         self.logger: Final[logging.Logger] = logging.getLogger(
             "pywikitools.resourcesbot.modules.write_report"
         )
@@ -69,16 +71,17 @@ class WriteReport(LanguagePostProcessor):
         english_changes: ChangeLog,
         *,
         force_rewrite: bool = False
-    ):
+    ) -> LanguageReport:
         """Entry function
 
         We run everything, and don't look at whether we have changes because we need to
         look at all CorrectBot reports and according to them, may need to rewrite
         the report even if changes and english_changes are empty
         """
+        self.lang_report = WriteReportLanguageReport(language_info.language_code)
         # We don't need a report for English as it is the source language
         if language_info.language_code == "en":
-            return
+            return self.lang_report
 
         # Don't write reports for language variants (except Brazilian Portuguese)
         # TODO: this should go somewhere else
@@ -86,8 +89,9 @@ class WriteReport(LanguagePostProcessor):
             "-" in language_info.language_code
             and language_info.language_code != "pt-br"
         ):
-            return
+            return self.lang_report
         self.save_language_report(language_info, english_info)
+        return self.lang_report
 
     def create_correctbot_mediawiki(self, worksheet: str, language_code: str) -> str:
         """Check Correctbot report status for one worksheet
@@ -164,7 +168,7 @@ class WriteReport(LanguagePostProcessor):
                 f"English name of language {language_info.language_code} empty! "
                 f"Skipping WriteReport"
             )
-            return
+            return self.lang_report
         page_url = f"4training:{language_info.english_name}"
         page = pywikibot.Page(self._site, page_url)
         report = self.create_mediawiki(language_info, english_info)
@@ -183,6 +187,7 @@ class WriteReport(LanguagePostProcessor):
                 self.logger.info(
                     f"Updated language report for {language_info.english_name}"
                 )
+            self.lang_report.updated_language_report = True
 
     def create_mediawiki(
         self, language_info: LanguageInfo, english_info: LanguageInfo
@@ -408,3 +413,32 @@ class WriteReport(LanguagePostProcessor):
             line_color = Color.GREEN
         content = f'|- style="background-color:{line_color}"\n' + content
         return content
+
+
+class WriteReportLanguageReport(LanguageReport):
+    """
+    A specialized report for write_report.
+    """
+
+    def __init__(self, language_code: str):
+        super().__init__(language_code)
+        self.updated_language_report = False
+
+    @classmethod
+    def get_module_name(cls) -> str:
+        return "write_report"
+
+    def get_summary(self) -> str:
+        if self.updated_language_report:
+            return (f"Updated language report for {self.language}.")
+        else:
+            return ""
+
+    @classmethod
+    def get_module_summary(cls, lang_reports: list) -> str:
+        if len(lang_reports) == 0:
+            return ""
+
+        updated_languages = [report for report in lang_reports if report.updated_language_report]
+
+        return (f"Updated language report for {len(updated_languages)}/{len(lang_reports)} languages.")

--- a/pywikitools/resourcesbot/modules/write_sidebar_messages.py
+++ b/pywikitools/resourcesbot/modules/write_sidebar_messages.py
@@ -8,6 +8,7 @@ from pywikitools.fortraininglib import ForTrainingLib
 from pywikitools.resourcesbot.changes import ChangeLog, ChangeType
 from pywikitools.resourcesbot.data_structures import LanguageInfo, WorksheetInfo
 from pywikitools.resourcesbot.modules.post_processing import LanguagePostProcessor
+from pywikitools.resourcesbot.reporting import LanguageReport
 
 
 class WriteSidebarMessages(LanguagePostProcessor):
@@ -44,6 +45,7 @@ class WriteSidebarMessages(LanguagePostProcessor):
         site: pywikibot.site.APISite
     ):
         super().__init__(fortraininglib, config, site)
+        self.lang_report = WriteSidebarReport("")
         self.logger: Final[logging.Logger] = logging.getLogger(
             "pywikitools.resourcesbot.modules.write_sidebar_messages"
         )
@@ -66,6 +68,7 @@ class WriteSidebarMessages(LanguagePostProcessor):
             self.logger.info(f"Updating system message {title}")
             page.text = worksheet.title
             page.save("Updated translated worksheet title")
+            self.lang_report.updated_worksheet_counter += 1
 
     @staticmethod
     def has_relevant_change(worksheet: str, changes: ChangeLog) -> bool:
@@ -91,10 +94,41 @@ class WriteSidebarMessages(LanguagePostProcessor):
         _english_changes,
         *,
         force_rewrite: bool = False
-    ) -> None:
+    ) -> LanguageReport:
         """Our entry function"""
+        self.lang_report = WriteSidebarReport(language_info.language_code)
         for worksheet in language_info.worksheets.values():
             if worksheet.title == "":
                 continue
             if force_rewrite or self.has_relevant_change(worksheet.page, changes):
                 self.save_worksheet_title(worksheet)
+        return self.lang_report
+
+
+class WriteSidebarReport(LanguageReport):
+    """
+    A specialized report for export_pdf,
+    containing information about saved pdfs
+    """
+
+    def __init__(self, language_code: str):
+        super().__init__(language_code)
+        self.updated_worksheet_counter = 0
+
+    @classmethod
+    def get_module_name(cls) -> str:
+        return "write_sidebar_messages"
+
+    def get_summary(self) -> str:
+        return (f"Ran write_sidebar_messages for {self.language}: "
+                f"Updated {self.updated_worksheet_counter} worksheet titles.")
+
+    @classmethod
+    def get_module_summary(cls, lang_reports: list) -> str:
+        if len(lang_reports) == 0:
+            return ""
+
+        total_updated_titles = sum(report.updated_worksheet_counter for report in lang_reports)
+
+        return (f"Ran write_sidebar_messages for {len(lang_reports)} languages: "
+                f"Updated {total_updated_titles} worksheet titles.")

--- a/pywikitools/resourcesbot/reporting.py
+++ b/pywikitools/resourcesbot/reporting.py
@@ -1,0 +1,46 @@
+"""
+Contains the data-structures and main methods for the reporting.
+Through reporting, the ressources-bot keeps track of what it did.
+This information can then be made available to people who need to know what is going on.
+"""
+
+from abc import ABC, abstractmethod
+from typing import Dict, List
+
+
+class LanguageReport(ABC):
+    """
+    Basic data structure for the report of one module running once for one language.
+    """
+
+    def __init__(self, language_code: str):
+        self.language = language_code
+        self.summary_text = ""
+
+    def was_anything_to_report(self) -> bool:
+        return self.summary_text != ""
+
+    @abstractmethod
+    def get_summary(self) -> str:
+        return self.summary_text
+
+    @classmethod
+    @abstractmethod
+    def get_module_name(cls) -> str:
+        return ""
+
+    @classmethod
+    @abstractmethod
+    def get_module_summary(cls, lang_reports: list) -> str:
+        if len(lang_reports) == 0:
+            return ""
+        else:
+            return f"Ran module {cls.get_module_name()} for {len(lang_reports)} languages"
+
+
+def print_summaries(module_reports: Dict[str, List[LanguageReport]]):
+    for key, value in module_reports.items():
+        if len(value) == 0:
+            print(f"Module {key}: Empty Report")
+        else:
+            print(f"Module {key}'s report: {type(value[0]).get_module_summary(value)}")

--- a/pywikitools/resourcesbot/reporting.py
+++ b/pywikitools/resourcesbot/reporting.py
@@ -6,6 +6,9 @@ This information can then be made available to people who need to know what is g
 
 from abc import ABC, abstractmethod
 from typing import Dict, List
+from datetime import datetime
+
+import pywikibot
 
 
 class LanguageReport(ABC):
@@ -39,8 +42,49 @@ class LanguageReport(ABC):
 
 
 def print_summaries(module_reports: Dict[str, List[LanguageReport]]):
+    print(make_summaries(module_reports))
+
+
+def make_summaries(module_reports: Dict[str, List[LanguageReport]]):
+    summary = ""
     for key, value in module_reports.items():
         if len(value) == 0:
-            print(f"Module {key}: Empty Report")
+            summary = f"Module {key}: Empty Report"
         else:
-            print(f"Module {key}'s report: {type(value[0]).get_module_summary(value)}")
+            summary += f"Module {key}'s report: {type(value[0]).get_module_summary(value)}\n"
+    return summary
+
+
+def generate_mediawiki_overview(module_reports: Dict[str, List[LanguageReport]]):
+    mediawiki = "===Overview===\n\n"
+    for key, value in module_reports.items():
+        if len(value) == 0:
+            mediawiki = f"*Module '''{key}''': Empty Report\n\n"
+        else:
+            mediawiki += f"*Module '''{key}''''s report: {type(value[0]).get_module_summary(value)}\n\n"
+    return mediawiki
+
+
+def generate_mediawiki(module_reports: Dict[str, List[LanguageReport]]):
+    timestamp_str = datetime.now().strftime("%Y-%m-%d--%H:%M")
+    head = f"==Resourcesbot-run at {timestamp_str}==\n\n"
+    overview = generate_mediawiki_overview(module_reports)
+    details = "===Detailed Reports per Module===\n\n"
+    for key, value in module_reports.items():
+        if len(value) == 0:
+            pass
+        else:
+            details += f"===={key}====\n\n"
+            for lang_report in value:
+                details += f"*{lang_report.get_summary()}\n\n"
+    return head + overview + details
+
+
+def save_report(site, module_reports: Dict[str, List[LanguageReport]]):
+    page_url = "4training:Resourcesbot.report"
+    page = pywikibot.Page(site, page_url)
+    if page.exists():
+        page.text = generate_mediawiki(module_reports) + page.text
+    else:
+        page.text = generate_mediawiki(module_reports)
+    page.save("Created summary for Resourcesbot run")

--- a/pywikitools/test/test_resourcesbot.py
+++ b/pywikitools/test/test_resourcesbot.py
@@ -164,8 +164,10 @@ class TestResourcesBot(unittest.TestCase):
     @patch("pywikitools.resourcesbot.modules.export_html.ExportHTML.run", autospec=True)
     @patch("pywikitools.resourcesbot.modules.export_pdf.ExportPDF.run", autospec=True)
     @patch("pywikitools.resourcesbot.modules.consistency_checks.ConsistencyCheck.run", autospec=True)
+    @patch("pywikitools.resourcesbot.reporting.print_summaries", autospec=True)
     def test_run_with_cache(
         self,
+        mock_reporting_summary,
         mock_consistency_check,
         mock_export_pdf,
         mock_export_html,
@@ -175,13 +177,12 @@ class TestResourcesBot(unittest.TestCase):
         mock_write_report,
         mock_write_summary,
         mock_pywikibot_page,
-        mock_pywikibot_site,
+        mock_pywikibot_site
     ):
         mock_pywikibot_page.side_effect = self.json_test_loader
         mock_pywikibot_site.return_value.logged_in.return_value = True
         bot = ResourcesBot(config=self.config, read_from_cache=True)
         bot.run()
-
         # run() function of each LanguagePostProcessor should get called 2x (for English and Russian)
         self.assertEqual(mock_consistency_check.call_count, 2)
         self.assertEqual(mock_export_pdf.call_count, 2)
@@ -211,8 +212,10 @@ class TestResourcesBot(unittest.TestCase):
     @patch("pywikitools.resourcesbot.modules.export_html.ExportHTML.run", autospec=True)
     @patch("pywikitools.resourcesbot.modules.export_pdf.ExportPDF.run", autospec=True)
     @patch("pywikitools.resourcesbot.modules.consistency_checks.ConsistencyCheck.run", autospec=True)
+    @patch("pywikitools.resourcesbot.reporting.print_summaries", autospec=True)
     def test_rewrite_options(
         self,
+        mock_reporting_summary,
         mock_consistency_check,
         mock_export_pdf,
         mock_export_html,

--- a/pywikitools/test/test_resourcesbot.py
+++ b/pywikitools/test/test_resourcesbot.py
@@ -165,9 +165,11 @@ class TestResourcesBot(unittest.TestCase):
     @patch("pywikitools.resourcesbot.modules.export_pdf.ExportPDF.run", autospec=True)
     @patch("pywikitools.resourcesbot.modules.consistency_checks.ConsistencyCheck.run", autospec=True)
     @patch("pywikitools.resourcesbot.reporting.print_summaries", autospec=True)
+    @patch("pywikitools.resourcesbot.reporting.save_report", autospec=True)
     def test_run_with_cache(
         self,
-        mock_reporting_summary,
+        mock_save_report,
+        mock_print_summary,
         mock_consistency_check,
         mock_export_pdf,
         mock_export_html,
@@ -213,8 +215,10 @@ class TestResourcesBot(unittest.TestCase):
     @patch("pywikitools.resourcesbot.modules.export_pdf.ExportPDF.run", autospec=True)
     @patch("pywikitools.resourcesbot.modules.consistency_checks.ConsistencyCheck.run", autospec=True)
     @patch("pywikitools.resourcesbot.reporting.print_summaries", autospec=True)
+    @patch("pywikitools.resourcesbot.reporting.save_report", autospec=True)
     def test_rewrite_options(
         self,
+        mock_save_report,
         mock_reporting_summary,
         mock_consistency_check,
         mock_export_pdf,


### PR DESCRIPTION
Making a draft pull request to add my comments: The overall direction is good 👍

Having several top-level functions in `reporting.py` doesn't feel very good. Instead you can introduce a class `Reporting` (or `OverallReport` or something like that) to hold all this functions. Then you can integrate that variable `module_report: Dict[str, List[LanguageReport]]` into this class. Then in `bot.py` you just need to say `module_report = Reporting()` and hide that more complex data structure into this class

The detailled reports should be grouped by languages, not by modules. Also it would be better to omit modules where nothing significant happened and then also completely omit languages where nothing happened.

I'm thinking about the names of these classes, it doesn't feel really good yet. A main issue is that the module `WriteReport` is colliding with this whole reporting topic. I think I came up with a resolution:
- rename `WriteReport` to `WriteTranslationProgress` (and shortcut is `progress`)
- rename `WriteSummary` to `WriteProgressSummary` (shortcut can continue to be `summary`)
- (what do you think? or just `WriteProgress` instead of `WriteTranslationProgress`?. Alternatively use the word "status"...)

Then we can just name the abstract base class `Report` (not `LanguageReport`) and simplify the names of all implementing classes. The new class I proposed above could also be named `ReportSummary`.

Some minor coding style comments: 
- [R1705 no else after return](https://pylint.readthedocs.io/en/latest/user_guide/checkers/features.html)
- [R1703 simplify if statement](https://pylint.readthedocs.io/en/latest/user_guide/checkers/features.html) in `consistency_checks.py`

Each report should go into its own mediawiki page, the name should include the date YYYY-MM-DD. In case that already exists then add the run summary to that existing page at the bottom (always mentioning the date in a headline as you already do). Later when everything is automated there should only be one run per day but in case there is an extra manual resourcesbot run we want to have its information as well.
And then always forward the page `4training:Resourcesbot.report` to the most recent resourcesbot run page.
It would also be nice to add a [category](https://www.mediawiki.org/wiki/Help:Categories) `Resourcesbot run` to the created pages, then we can quickly have a category overview page to see and access all resourcesbot run reports.